### PR TITLE
[patch] Fixing Facilities installation

### DIFF
--- a/9.1.x/pipeline.yaml
+++ b/9.1.x/pipeline.yaml
@@ -1122,6 +1122,6 @@ spec:
               export DB2_ENTITLEMENT_KEY=$(cat $(workspaces.ws.path)/ek.dat)
               export MAS_CATALOG_VERSION=$(params.mas-catalog-version)
               export MAS_APP_CHANNEL=$(params.mas-channel)
-
+              export MAS_APP_ID=facilities
 
               ansible-playbook ibm.mas_devops.oneclick_add_facilities


### PR DESCRIPTION
Facilities installation is failing as it cannot get Facilities application name.
This PR is adding a new env var to fix the bug during JDBC config creation for Facilities.